### PR TITLE
Properly install kernelspec on initialization

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -21,18 +21,22 @@ install_env() {
   echo "Installing shallow virtual environment in \$PWD/.env..."
   python -m venv --without-pip --system-site-packages .env
   unlink .env/lib64  # HTCondor can't transfer symlink to directory and it appears optional
+  # work around issues copying CVMFS xattr when copying to tmpdir
+  export TMPDIR=\$(mktemp -d -p .)
+  .env/bin/python -m ipykernel install --user
+  rm -rf \$TMPDIR && unset TMPDIR
   .env/bin/python -m pip install -q git+https://github.com/CoffeaTeam/lpcjobqueue.git@v0.2.3
   echo "done."
 }
-
-[[ -d .env ]] || install_env
-source .env/bin/activate
-alias pip="python -m pip"
 
 export JUPYTER_PATH=/srv/.jupyter
 export JUPYTER_RUNTIME_DIR=/srv/.local/share/jupyter/runtime
 export JUPYTER_DATA_DIR=/srv/.local/share/jupyter
 export IPYTHONDIR=/srv/.ipython
+
+[[ -d .env ]] || install_env
+source .env/bin/activate
+alias pip="python -m pip"
 EOF
 
 chmod u+x shell .bashrc


### PR DESCRIPTION
Seems on LPC the `/tmp` mount cannot accept the xattr from cvmfs.
Min repro:
```bash
Singularity> cp --preserve=all /opt/conda/lib/python3.8/site-packages/ipykernel/resources/logo-32x32.png /tmp/blah
cp: setting attribute 'user.repo_metainfo' for 'user.repo_metainfo': No space left on device
```