### PR TITLE
Fix: use `nbytes` for Awkward Arrays

### DIFF
--- a/src/lpcjobqueue/patch.py
+++ b/src/lpcjobqueue/patch.py
@@ -7,6 +7,10 @@ from dask.sizeof import sizeof
 
 
 @sizeof.register(awkward.highlevel.Array)
+def sizeof_uproot_generic(obj):
+    return obj.nbytes
+
+
 @sizeof.register(uproot.model.Model)
 def sizeof_uproot_generic(obj):
     return obj.num_bytes

--- a/src/lpcjobqueue/patch.py
+++ b/src/lpcjobqueue/patch.py
@@ -7,7 +7,7 @@ from dask.sizeof import sizeof
 
 
 @sizeof.register(awkward.highlevel.Array)
-def sizeof_uproot_generic(obj):
+def sizeof_awkward_generic(obj):
     return obj.nbytes
 
 


### PR DESCRIPTION
Hey! I haven't tested this repo, but I was looking through the source and noticed that the `sizeof` implementation registers for Awkward's `Array`. AFAICT we don't have `num_bytes` for any version of Awkward, so I assume that this currently does not work?