### PR TITLE
bash script as an executable in LPCClusterJob

### DIFF
--- a/src/lpcjobqueue/cluster.py
+++ b/src/lpcjobqueue/cluster.py
@@ -39,7 +39,7 @@ def is_venv():
 
 
 class LPCCondorJob(HTCondorJob):
-    executable = "/usr/bin/env"
+    executable = os.path.dirname(os.path.abspath(__file__)) + '/condor_exec.exe'
     container_prefix = "/cvmfs/unpacked.cern.ch/registry.hub.docker.com/"
     config_name = "lpccondor"
     known_jobs = set()

--- a/src/lpcjobqueue/condor_exec.exe
+++ b/src/lpcjobqueue/condor_exec.exe
@@ -1,0 +1,2 @@
+#!/bin/bash
+/usr/bin/env ${@}

--- a/src/lpcjobqueue/condor_exec.exe
+++ b/src/lpcjobqueue/condor_exec.exe
@@ -1,2 +1,2 @@
 #!/bin/bash
-/usr/bin/env ${@}
+${@}


### PR DESCRIPTION
Fixes issue with LPC HTCondor 9.0.1 update that causes worker nodes to be immediately terminated with the error message:
```
/.singularity.d/actions/exec: 21: exec: ./condor_exec.exe: not found
```