### PR TITLE
Update to account for missing configuration defaults

### DIFF
--- a/src/lpcjobqueue/cluster.py
+++ b/src/lpcjobqueue/cluster.py
@@ -81,21 +81,6 @@ class LPCCondorJob(HTCondorJob):
             }
         )
 
-    def job_script(self):
-        """Construct a job submission script"""
-        quoted_arguments = quote_arguments(self._command_template.split(" "))
-        quoted_environment = quote_environment(self.env_dict)
-        job_header_lines = "\n".join(
-            "%s = %s" % (k, v) for k, v in self.job_header_dict.items()
-        )
-        return self._script_template % {
-            "shebang": self.shebang,
-            "job_header": job_header_lines,
-            "quoted_environment": quoted_environment,
-            "quoted_arguments": quoted_arguments,
-            "executable": self.executable,
-        }
-
     async def start(self):
         """Start workers and point them to our local scheduler"""
         logger.info("Starting worker: %s", self.name)
@@ -298,9 +283,9 @@ class LPCCondorCluster(HTCondorCluster):
         prepared_input_files = await self.loop.run_in_executor(
             None, self._build_scratch
         )
-        self._job_kwargs.setdefault("job_extra", {})
-        self._job_kwargs["job_extra"]["initialdir"] = self.scratch_area.name
-        self._job_kwargs["job_extra"]["transfer_input_files"] = ",".join(
+        self._job_kwargs.setdefault("job_extra_directives", {})
+        self._job_kwargs["job_extra_directives"]["initialdir"] = self.scratch_area.name
+        self._job_kwargs["job_extra_directives"]["transfer_input_files"] = ",".join(
             prepared_input_files
         )
 

--- a/src/lpcjobqueue/cluster.py
+++ b/src/lpcjobqueue/cluster.py
@@ -57,9 +57,9 @@ class LPCCondorJob(HTCondorJob):
         if ship_env:
             base_class_kwargs["python"] = ".env/bin/python"
             base_class_kwargs.setdefault(
-                "extra", list(dask.config.get("jobqueue.%s.extra" % self.config_name))
+                "worker_extra_args", list(dask.config.get("jobqueue.%s.worker_extra_args" % self.config_name))
             )
-            base_class_kwargs["extra"].extend(["--preload", "lpcjobqueue.patch"])
+            base_class_kwargs["worker_extra_args"].extend(["--preload", "lpcjobqueue.patch"])
         else:
             base_class_kwargs["python"] = "python"
         super().__init__(scheduler=scheduler, name=name, **base_class_kwargs)

--- a/src/lpcjobqueue/condor_exec.exe
+++ b/src/lpcjobqueue/condor_exec.exe
@@ -1,2 +1,4 @@
 #!/bin/bash
-${@}
+# htcondor jobqueue executable is /bin/sh, so
+# we emulate /bin/sh -c "command" behavior
+$2

--- a/src/lpcjobqueue/config.yaml
+++ b/src/lpcjobqueue/config.yaml
@@ -10,12 +10,21 @@ jobqueue:
     interface: null             # Network interface to use like eth0 or ib0
     death-timeout: 60           # Number of seconds to wait if a worker can not find a scheduler
     local-directory: /srv       # Location of fast local storage like /scratch or $TMPDIR
-    extra: ["--worker-port 10000:10070", "--nanny-port 10070:10100", "--no-dashboard"]
+    shared-temp-directory: null
+    extra: null
+    worker-extra-args: ["--worker-port 10000:10070", "--nanny-port 10070:10100", "--no-dashboard"]
 
     # HTCondor Resource Manager options
     disk: 200MB                  # Total amount of disk per job
-    env-extra: []
     job-extra: {}               # Extra submit attributes
+    log-directory: null
+    env-extra: null
+    job-script-prologue: []
+    job-extra: null             # Extra submit attributes
+    job-extra-directives: {}    # Extra submit attributes
+    job-directives-skip: []
+    submit-command-extra: []    # Extra condor_submit arguments
+    cancel-command-extra: []    # Extra condor_rm arguments
     log-directory: null
     shebang: "#!/usr/bin/env condor_submit" # doesn't matter
     


### PR DESCRIPTION
Since we have our own cluster type, we have to keep up-to-date to changes in the defaults as specified in https://github.com/dask/dask-jobqueue/blob/main/dask_jobqueue/jobqueue.yaml
In particular, `shared_temp_directory` was missing for some time, and more recently dask-jobqueue config went through a renaming campaign https://github.com/dask/dask-jobqueue/pull/576