### PR TITLE
use which to get proper shell

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -10,7 +10,7 @@ else
   export COFFEA_IMAGE=\$1
 fi
 
-singularity exec -B \${PWD}:/srv -B /cvmfs -B /uscmst1b_scratch --pwd /srv \\
+SINGULARITY_SHELL=\$(which bash) singularity exec -B \${PWD}:/srv -B /cvmfs -B /uscmst1b_scratch --pwd /srv \\
   /cvmfs/unpacked.cern.ch/registry.hub.docker.com/\${COFFEA_IMAGE} \\
   /bin/bash --rcfile /srv/.bashrc
 EOF


### PR DESCRIPTION
Ran into some strange cases where zsh mixed with bash could have been calling strange installation patterns. This should remove that possibility.