### PR TITLE
Only acquire schedd if we use it

### DIFF
--- a/src/lpcjobqueue/cluster.py
+++ b/src/lpcjobqueue/cluster.py
@@ -96,11 +96,11 @@ class LPCCondorJob(HTCondorJob):
         def sub():
             try:
                 classads = []
-                with SCHEDD.transaction() as txn:
+                with SCHEDD().transaction() as txn:
                     cluster_id = job.queue(txn, ad_results=classads)
 
                 logger.debug(f"ClassAds for job {cluster_id}: {classads}")
-                SCHEDD.spool(classads)
+                SCHEDD().spool(classads)
                 return cluster_id
             except htcondor.HTCondorInternalError as ex:
                 logger.error(str(ex))
@@ -136,7 +136,7 @@ class LPCCondorJob(HTCondorJob):
 
         def check_gone():
             try:
-                return len(SCHEDD.query(f"ClusterId == {self.job_id}")) == 0
+                return len(SCHEDD().query(f"ClusterId == {self.job_id}")) == 0
             except htcondor.HTCondorIOError as ex:
                 logger.error(str(ex))
                 return False
@@ -168,7 +168,7 @@ class LPCCondorJob(HTCondorJob):
 
         def stop():
             try:
-                res = SCHEDD.act(
+                res = SCHEDD().act(
                     htcondor.JobAction.Remove, f"ClusterId == {self.job_id}"
                 )
                 if res["TotalSuccess"] == 1 and res["TotalChangedAds"] == 1:
@@ -195,7 +195,7 @@ class LPCCondorJob(HTCondorJob):
                 f"Last-ditch attempt to close HTCondor job {job_id} in finalizer! You should confirm the job exits!"
             )
             try:
-                SCHEDD.act(htcondor.JobAction.Remove, f"ClusterId == {job_id}")
+                SCHEDD().act(htcondor.JobAction.Remove, f"ClusterId == {job_id}")
             except htcondor.HTCondorIOError as ex:
                 logger.error(str(ex))
             cls.known_jobs.discard(job_id)

--- a/src/lpcjobqueue/schedd.py
+++ b/src/lpcjobqueue/schedd.py
@@ -1,4 +1,5 @@
 import concurrent.futures
+import functools
 import logging
 import os
 import re
@@ -77,8 +78,8 @@ def acquire_schedd():
 
 # Pick a schedd once on import
 # Would prefer one per cluster but there is a quite scary weakref.finalize
-# that depends on it
-SCHEDD = acquire_schedd()
+# that depends on it. Wrap with a memoized getter to avoid setup if not used
+SCHEDD = functools.cache(acquire_schedd)
 # The htcondor binding has a global lock so there's no point in using more than
 # one pool for asyncio run_in_executor
 SCHEDD_POOL = concurrent.futures.ThreadPoolExecutor(1)

--- a/src/lpcjobqueue/schedd.py
+++ b/src/lpcjobqueue/schedd.py
@@ -79,7 +79,7 @@ def acquire_schedd():
 # Pick a schedd once on import
 # Would prefer one per cluster but there is a quite scary weakref.finalize
 # that depends on it. Wrap with a memoized getter to avoid setup if not used
-SCHEDD = functools.cache(acquire_schedd)
+SCHEDD = functools.lru_cache(acquire_schedd)
 # The htcondor binding has a global lock so there's no point in using more than
 # one pool for asyncio run_in_executor
 SCHEDD_POOL = concurrent.futures.ThreadPoolExecutor(1)


### PR DESCRIPTION
Fixes a bug introduced with the new behavior of #21 when using `ship_env=True` that makes workers immediately die on startup.