### PR TITLE
bind all files/paths needed for host condor config

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -38,6 +38,7 @@ install_env() {
   rm -rf \$TMPDIR && unset TMPDIR
   .env/bin/python -m pip install -q git+https://github.com/CoffeaTeam/lpcjobqueue.git@v\${LPCJQ_VERSION}
   echo "done."
+  set +e
 }
 
 export JUPYTER_PATH=/srv/.jupyter

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -20,7 +20,7 @@ else
   export COFFEA_IMAGE=\$1
 fi
 
-export APPTAINER_BINDPATH=/uscmst1b_scratch,/storage,/cvmfs,/cvmfs/grid.cern.ch/etc/grid-security:/etc/grid-security,${LPC_CONDOR_CONFIG},/usr/local/bin/cmslpc-local-conf.py,python3:/usr/bin/python3
+export APPTAINER_BINDPATH=/uscmst1b_scratch,/storage,/cvmfs,/cvmfs/grid.cern.ch/etc/grid-security:/etc/grid-security,${LPC_CONDOR_CONFIG},/usr/local/bin/cmslpc-local-conf.py,.python3:/usr/bin/python3
 
 APPTAINER_SHELL=\$(which bash) apptainer exec -B \${PWD}:/srv --pwd /srv \\
   /cvmfs/unpacked.cern.ch/registry.hub.docker.com/\${COFFEA_IMAGE} \\
@@ -61,10 +61,10 @@ alias pip="python -m pip"
 pip show lpcjobqueue 2>/dev/null | grep -q "Version: \${LPCJQ_VERSION}" || pip install -q git+https://github.com/CoffeaTeam/lpcjobqueue.git@v\${LPCJQ_VERSION}
 EOF
 
-cat <<'EOF' > python3
+cat <<'EOF' > .python3
 #!/usr/bin/env bash
 python3 "$@"
 EOF
 
-chmod u+x shell .bashrc python3
+chmod u+x shell .bashrc .python3
 echo "Wrote shell and .bashrc to current directory. You can delete this file. Run ./shell to start the apptainer shell"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -20,7 +20,7 @@ fi
 
 grep -v '^include' /etc/condor/config.d/01_cmslpc_interactive > .condor_config
 
-export APPTAINER_BINDPATH=/uscmst1b_scratch,/cvmfs,/cvmfs/grid.cern.ch/etc/grid-security:/etc/grid-security
+export APPTAINER_BINDPATH=/uscmst1b_scratch,/storage,/cvmfs,/cvmfs/grid.cern.ch/etc/grid-security:/etc/grid-security,/etc/condor/config.d/01_cmslpc_interactive,/usr/local/bin/cmslpc-local-conf.py
 
 APPTAINER_SHELL=\$(which bash) apptainer exec -B \${PWD}:/srv --pwd /srv \\
   /cvmfs/unpacked.cern.ch/registry.hub.docker.com/\${COFFEA_IMAGE} \\

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+LPC_CONDOR_CONFIG=/etc/condor/config.d/01_cmslpc_interactive
+
 cat <<EOF > shell
 #!/usr/bin/env bash
 
@@ -18,11 +20,16 @@ else
   export COFFEA_IMAGE=\$1
 fi
 
-export APPTAINER_BINDPATH=/uscmst1b_scratch,/storage,/cvmfs,/cvmfs/grid.cern.ch/etc/grid-security:/etc/grid-security,/etc/condor/config.d/01_cmslpc_interactive,/usr/local/bin/cmslpc-local-conf.py,python3:/usr/bin/python3
+export APPTAINER_BINDPATH=/uscmst1b_scratch,/storage,/cvmfs,/cvmfs/grid.cern.ch/etc/grid-security:/etc/grid-security,${LPC_CONDOR_CONFIG},/usr/local/bin/cmslpc-local-conf.py,python3:/usr/bin/python3
 
 APPTAINER_SHELL=\$(which bash) apptainer exec -B \${PWD}:/srv --pwd /srv \\
   /cvmfs/unpacked.cern.ch/registry.hub.docker.com/\${COFFEA_IMAGE} \\
   /bin/bash --rcfile /srv/.bashrc
+EOF
+
+cat <<EOF > .condor_config
+REQUIRE_LOCAL_CONFIG_FILE = false
+include : ${LPC_CONDOR_CONFIG}
 EOF
 
 cat <<EOF > .bashrc
@@ -41,7 +48,7 @@ install_env() {
   set +e
 }
 
-export CONDOR_CONFIG=/etc/condor/config.d/01_cmslpc_interactive
+export CONDOR_CONFIG=/srv/.condor_config
 export JUPYTER_PATH=/srv/.jupyter
 export JUPYTER_RUNTIME_DIR=/srv/.local/share/jupyter/runtime
 export JUPYTER_DATA_DIR=/srv/.local/share/jupyter

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -18,7 +18,7 @@ else
   export COFFEA_IMAGE=\$1
 fi
 
-export APPTAINER_BINDPATH=/uscmst1b_scratch,/storage,/cvmfs,/cvmfs/grid.cern.ch/etc/grid-security:/etc/grid-security,/etc/condor/config.d/01_cmslpc_interactive,/usr/local/bin/cmslpc-local-conf.py
+export APPTAINER_BINDPATH=/uscmst1b_scratch,/storage,/cvmfs,/cvmfs/grid.cern.ch/etc/grid-security:/etc/grid-security,/etc/condor/config.d/01_cmslpc_interactive,/usr/local/bin/cmslpc-local-conf.py,python3:/usr/bin/python3
 
 APPTAINER_SHELL=\$(which bash) apptainer exec -B \${PWD}:/srv --pwd /srv \\
   /cvmfs/unpacked.cern.ch/registry.hub.docker.com/\${COFFEA_IMAGE} \\
@@ -54,5 +54,10 @@ alias pip="python -m pip"
 pip show lpcjobqueue 2>/dev/null | grep -q "Version: \${LPCJQ_VERSION}" || pip install -q git+https://github.com/CoffeaTeam/lpcjobqueue.git@v\${LPCJQ_VERSION}
 EOF
 
-chmod u+x shell .bashrc
+cat <<'EOF' > python3
+#!/usr/bin/env bash
+python3 "$@"
+EOF
+
+chmod u+x shell .bashrc python3
 echo "Wrote shell and .bashrc to current directory. You can delete this file. Run ./shell to start the apptainer shell"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -18,8 +18,6 @@ else
   export COFFEA_IMAGE=\$1
 fi
 
-grep -v '^include' /etc/condor/config.d/01_cmslpc_interactive > .condor_config
-
 export APPTAINER_BINDPATH=/uscmst1b_scratch,/storage,/cvmfs,/cvmfs/grid.cern.ch/etc/grid-security:/etc/grid-security,/etc/condor/config.d/01_cmslpc_interactive,/usr/local/bin/cmslpc-local-conf.py
 
 APPTAINER_SHELL=\$(which bash) apptainer exec -B \${PWD}:/srv --pwd /srv \\

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -20,7 +20,7 @@ else
   export COFFEA_IMAGE=\$1
 fi
 
-export APPTAINER_BINDPATH=/uscmst1b_scratch,/cvmfs,/cvmfs/grid.cern.ch/etc/grid-security:/etc/grid-security,${LPC_CONDOR_CONFIG},/usr/local/bin/cmslpc-local-conf.py,.python3:/usr/bin/python3
+export APPTAINER_BINDPATH=${APPTAINER_BINDPATH}${APPTAINER_BINDPATH:+,}/uscmst1b_scratch,/cvmfs,/cvmfs/grid.cern.ch/etc/grid-security:/etc/grid-security,${LPC_CONDOR_CONFIG},/usr/local/bin/cmslpc-local-conf.py,.python3:/usr/bin/python3
 
 APPTAINER_SHELL=\$(which bash) apptainer exec -B \${PWD}:/srv --pwd /srv \\
   /cvmfs/unpacked.cern.ch/registry.hub.docker.com/\${COFFEA_IMAGE} \\

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -41,6 +41,7 @@ install_env() {
   set +e
 }
 
+export CONDOR_CONFIG=/etc/condor/config.d/01_cmslpc_interactive
 export JUPYTER_PATH=/srv/.jupyter
 export JUPYTER_RUNTIME_DIR=/srv/.local/share/jupyter/runtime
 export JUPYTER_DATA_DIR=/srv/.local/share/jupyter

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -30,12 +30,7 @@ EOF
 
 cat <<EOF > .cmslpc-local-conf
 #!/bin/bash
-python3 ${LPC_CONDOR_LOCAL}.orig
-EOF
-
-cat <<EOF > .condor_config
-REQUIRE_LOCAL_CONFIG_FILE = false
-include : ${LPC_CONDOR_CONFIG}
+python3 ${LPC_CONDOR_LOCAL}.orig | grep -v "LOCAL_CONFIG_FILE"
 EOF
 
 cat <<EOF > .bashrc
@@ -54,7 +49,7 @@ install_env() {
   set +e
 }
 
-export CONDOR_CONFIG=/srv/.condor_config
+export CONDOR_CONFIG=${LPC_CONDOR_CONFIG}
 export JUPYTER_PATH=/srv/.jupyter
 export JUPYTER_RUNTIME_DIR=/srv/.local/share/jupyter/runtime
 export JUPYTER_DATA_DIR=/srv/.local/share/jupyter

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -20,7 +20,7 @@ else
   export COFFEA_IMAGE=\$1
 fi
 
-export APPTAINER_BINDPATH=/uscmst1b_scratch,/storage,/cvmfs,/cvmfs/grid.cern.ch/etc/grid-security:/etc/grid-security,${LPC_CONDOR_CONFIG},/usr/local/bin/cmslpc-local-conf.py,.python3:/usr/bin/python3
+export APPTAINER_BINDPATH=/uscmst1b_scratch,/cvmfs,/cvmfs/grid.cern.ch/etc/grid-security:/etc/grid-security,${LPC_CONDOR_CONFIG},/usr/local/bin/cmslpc-local-conf.py,.python3:/usr/bin/python3
 
 APPTAINER_SHELL=\$(which bash) apptainer exec -B \${PWD}:/srv --pwd /srv \\
   /cvmfs/unpacked.cern.ch/registry.hub.docker.com/\${COFFEA_IMAGE} \\

--- a/src/lpcjobqueue/schedd.py
+++ b/src/lpcjobqueue/schedd.py
@@ -5,10 +5,9 @@ import os
 import re
 
 logger = logging.getLogger(__name__)
-os.environ["CONDOR_CONFIG"] = os.path.join("/srv/.condor_config")
+os.environ["CONDOR_CONFIG"] = os.path.join("/etc/condor/config.d/01_cmslpc_interactive")
 if not os.path.isfile(os.environ['CONDOR_CONFIG']):
-    logger.warn(f"Condor configuration not found! run the following command outside the apptainer instance")
-    logger.warn(f"grep -v '^include' /etc/condor/config.d/01_cmslpc_interactive > .condor_config")
+    logger.warn(f"Condor configuration not found! rerun bootstrap.sh to update shell")
 import htcondor  # noqa: E402
 
 

--- a/src/lpcjobqueue/schedd.py
+++ b/src/lpcjobqueue/schedd.py
@@ -5,8 +5,8 @@ import os
 import re
 
 logger = logging.getLogger(__name__)
-if not os.path.isfile(os.environ['CONDOR_CONFIG']):
-    logger.warn(f"Condor configuration {os.environ['CONDOR_CONFIG']} not found! rerun bootstrap.sh to update shell")
+if 'CONDOR_CONFIG' not in os.environ or not os.path.isfile(os.environ['CONDOR_CONFIG']):
+    logger.warn(f"Condor configuration {os.environ.get('CONDOR_CONFIG', '')} not found! Rerun bootstrap.sh to update shell")
 import htcondor  # noqa: E402
 
 

--- a/src/lpcjobqueue/schedd.py
+++ b/src/lpcjobqueue/schedd.py
@@ -5,8 +5,12 @@ import os
 import re
 
 logger = logging.getLogger(__name__)
-if 'CONDOR_CONFIG' not in os.environ or not os.path.isfile(os.environ['CONDOR_CONFIG']):
-    logger.warn(f"Condor configuration {os.environ.get('CONDOR_CONFIG', '')} not found! Rerun bootstrap.sh to update shell")
+if "CONDOR_CONFIG" not in os.environ or not os.path.isfile(os.environ["CONDOR_CONFIG"]):
+    raise RuntimeError(
+        f"Condor configuration {os.environ.get('CONDOR_CONFIG', '')} not found!\n"
+        "Please download and run bootstrap.sh again to update the shell with:\n"
+        "curl -OL https://raw.githubusercontent.com/CoffeaTeam/lpcjobqueue/main/bootstrap.sh; bash bootstrap.sh"
+    )
 import htcondor  # noqa: E402
 
 

--- a/src/lpcjobqueue/schedd.py
+++ b/src/lpcjobqueue/schedd.py
@@ -5,9 +5,8 @@ import os
 import re
 
 logger = logging.getLogger(__name__)
-os.environ["CONDOR_CONFIG"] = os.path.join("/etc/condor/config.d/01_cmslpc_interactive")
 if not os.path.isfile(os.environ['CONDOR_CONFIG']):
-    logger.warn(f"Condor configuration not found! rerun bootstrap.sh to update shell")
+    logger.warn(f"Condor configuration {os.environ['CONDOR_CONFIG']} not found! rerun bootstrap.sh to update shell")
 import htcondor  # noqa: E402
 
 


### PR DESCRIPTION
This will improve resiliency to minor changes in the LPC condor configuration. (Major changes, e.g. new/different files or paths, would still require a manual update.)