### PR TITLE
avoid disabled schedds (prevent divide by zero error)

### DIFF
--- a/src/lpcjobqueue/schedd.py
+++ b/src/lpcjobqueue/schedd.py
@@ -40,7 +40,7 @@ def acquire_schedd():
                     "RecentDaemonCoreDutyCycle",
                     "TotalIdleJobs",
                 ],
-                constraint='FERMIHTC_DRAIN_LPCSCHEDD=?=FALSE && FERMIHTC_SCHEDD_TYPE=?="CMSLPC"',
+                constraint='FERMIHTC_DRAIN_LPCSCHEDD=?=FALSE && FERMIHTC_SCHEDD_TYPE=?="CMSLPC" && MaxJobsRunning!=0',
             )
             if scheddAds:
                 break


### PR DESCRIPTION
Intended to avoid job submission failing during schedd upgrades.